### PR TITLE
.drone.yml : compress images right away, not after all builds completed

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,6 +54,7 @@ steps:
   - env | grep '^YNH_BUILDER' > userpatches/overlay/image_env.sh
   - ./compile.sh yunohost BOARD="$BOARD"
   - mv --no-clobber --no-target-directory output/images/Armbian_*.img 'output/images/'"$IMAGE_NAME_PREFIX"'_'`cat userpatches/overlay/yunohost_version`'_'"$DRONE_TAG"'_'"$BOARD"'.img'
+  - gzip -v output/images/*.img || ls -lh output/images/*.img.gz  
   when:
     event: tag
 
@@ -96,17 +97,6 @@ steps:
     YNH_BUILDER_INSTALL_INTERNETCUBE: yes
     BOARD: orangepipcplus
     IMAGE_NAME_PREFIX: internetcube
-
-- name: compress images
-  image: armbian-builder
-  pull: never
-  volumes:
-  - name: output
-    path: /drone/src/output
-  commands:
-  - gzip -v output/images/*.img || ls -lh output/images/*.img.gz
-  when:
-    event: tag
 
 - name: publish pre-release on github
   image: plugins/github-release:1


### PR DESCRIPTION
I have no idea what I'm doing, but that should optimize disk space usage which is causing too many issues