### PR TITLE
chore: update actions version to use node 16 version

### DIFF
--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -94,11 +94,11 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Prepare.outputs.matrix)}}
 
     steps:
- 
+
       - name: Cache Gradle packages
         uses: actions/cache@v2
         env:
@@ -131,7 +131,7 @@ jobs:
 
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -141,7 +141,7 @@ jobs:
 
       - name: Checkout Armbian support scripts
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -173,7 +173,7 @@ jobs:
 
         run: |
 
-          CHUNK="${{ matrix.node }}"          
+          CHUNK="${{ matrix.node }}"
           cd build
           # use prepared configs
           sudo mkdir -p userpatches
@@ -181,7 +181,7 @@ jobs:
           # prepare host
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
           ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
-          
+
           if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
               sudo mkdir -p cache/toolchain build/cache/rootfs || true
               ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
@@ -200,7 +200,7 @@ jobs:
           sudo sshfs upload@users.armbian.com:/images output/images -o IdentityFile=~/.ssh/id_rsa
           # link build targets
           sudo ln -sf ../../temp/split-${CHUNK}.conf userpatches/targets.conf
-          ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"          
+          ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"
           # umount
           while mountpoint output/images -q
           do

--- a/.github/workflows/build-beta-kernel.yml
+++ b/.github/workflows/build-beta-kernel.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
       - name: Checkout Armbian build script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -54,7 +54,7 @@ jobs:
           git push
 
   Prepare:
-    
+
     name: "Finding changed kernels"
     needs: [ Merge ]
     runs-on: [self-hosted, Linux, small]
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -98,7 +98,7 @@ jobs:
           clean: false
 
       - name: Checkout support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -136,19 +136,19 @@ jobs:
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
           if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
               sudo mkdir -p cache/toolchain cache/rootfs || true
-              # umount 
+              # umount
               sudo umount cache/toolchain || true
               # erase below
               sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/*
               ! sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/* && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q cache/rootfs && sudo rm -rf cache/rootfs/* && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-          fi           
+          fi
           mkdir -p cache/hash${FILE_EXT}
           sudo rsync -ar --delete ../scripts/hash${FILE_EXT}/. cache/hash${FILE_EXT}/ 2> /dev/null
           sudo cp ../scripts/configs/* userpatches/
-          sudo rm -f userpatches/targets.conf          
+          sudo rm -f userpatches/targets.conf
           if [[ "$(cat ../build-kernel/build_type 2> /dev/null || true)" =~ stable|edge ]]; then
-            cat config/targets.conf | grep edge | grep cli | grep hirsute | sudo tee userpatches/targets.conf 1>/dev/null 
+            cat config/targets.conf | grep edge | grep cli | grep hirsute | sudo tee userpatches/targets.conf 1>/dev/null
             echo "FILE_EXT=" >> $GITHUB_ENV
             echo "REPO_DEST=master" >> $GITHUB_ENV
             echo "BETA=no" >> $GITHUB_ENV
@@ -161,13 +161,13 @@ jobs:
           BETA="${{ env.BETA }}"
           MATRIX=$(cd build;./compile.sh all-new-beta-kernels BETA="$BETA" BUILD_ALL="demo" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | egrep "^[0-9]" | awk '{ print $2 ":" $4 }' | sort | uniq)
           mkdir -p build-kernel
-          echo "no" > build-kernel/skip          
+          echo "no" > build-kernel/skip
           if [[ -z "$MATRIX" ]]; then
               MATRIX="none:none"
               echo "yes" > build-kernel/skip
-          fi          
+          fi
           echo ::set-output name=matrix::$(for x in $(echo "${MATRIX}"); do echo $x; done|jq -cnR '[inputs | select(length>0)]' | jq)
-          
+
   Linux:
 
     name: "Build Linux"
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Prepare.outputs.matrix)}}
 
     steps:
@@ -190,7 +190,7 @@ jobs:
           if_key_exists: replace
 
       - name: Checkout Armbian support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -205,7 +205,7 @@ jobs:
           path: build-kernel
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux 
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Read value
@@ -239,10 +239,10 @@ jobs:
           done
           [[ -d build/.git ]] && sudo chown -R $USER:$USER build/.git || true
           [[ -d build/output/images ]] && sudo rm -rf build/output/images/* || true
- 
+
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -261,15 +261,15 @@ jobs:
               BOARD=$(echo $CHUNK | cut -d":" -f1)
               BRANCH=$(echo $CHUNK | cut -d":" -f2)
               echo "FILE_NAME=${BOARD}-${BRANCH}" >> $GITHUB_ENV
-              cd build              
+              cd build
               sudo rsync -ar --delete ../scripts/hash${FILE_EXT}/. cache/hash${FILE_EXT}/ 2> /dev/null
-              [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes          
-              ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" REPOSITORY_INSTALL="u-boot,kernel" 'prepare_host_basic'          
+              [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
+              ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" REPOSITORY_INSTALL="u-boot,kernel" 'prepare_host_basic'
               if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
                   sudo mkdir -p cache/toolchain cache/rootfs || true
                   ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                   ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-              fi 
+              fi
               rm -rf output/debs*
               ./compile.sh ARMBIAN_MIRROR="https://github.com/armbian/mirror/releases/download/" BOARD="$BOARD" CLEAN_LEVEL="alldebs" \
               PRIVATE_CCACHE="yes" BETA="$BETA" KERNEL_ONLY="yes" BRANCH="$BRANCH" KERNEL_CONFIGURE="no" OFFLINE="no"
@@ -279,7 +279,7 @@ jobs:
               RAZLIKA=$(diff -q "cache/hash${FILE_EXT}/" "../scripts/hash${FILE_EXT}/" | grep -v gitlog | cut -d" " -f2)
               [[ -n $RAZLIKA ]] && cp $RAZLIKA ../build-kernel/
               cp $(diff -q "cache/hash${FILE_EXT}/" "../scripts/hash${FILE_EXT}/" | grep -v gitlog | cut -d" " -f2) ../build-kernel/
-              echo "FILE_HASH=$(diff -q "cache/hash${FILE_EXT}/" "../scripts/hash${FILE_EXT}/" | grep -v gitlog | cut -d" " -f2)"  >> $GITHUB_ENV           
+              echo "FILE_HASH=$(diff -q "cache/hash${FILE_EXT}/" "../scripts/hash${FILE_EXT}/" | grep -v gitlog | cut -d" " -f2)"  >> $GITHUB_ENV
 
           fi
 
@@ -289,7 +289,7 @@ jobs:
         with:
           name: hash
           path: build/${{ env.FILE_HASH }}
-          
+
       - name: Upload build artifacts
         if: ${{ matrix.node != 'none:none' }}
         uses: actions/upload-artifact@v2
@@ -326,7 +326,7 @@ jobs:
           path: build-kernel
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux            
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
 
       - name: Read value
         run: |
@@ -342,7 +342,7 @@ jobs:
           fi
 
       - name: Checkout Armbian support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -360,13 +360,13 @@ jobs:
           git-commit-gpgsign: true
 
       - name: Download artefacts
-        if: ${{ env.SKIP != 'yes' }} 
+        if: ${{ env.SKIP != 'yes' }}
         uses: actions/download-artifact@v2
         with:
           name: hash
 
       - name: Update scripts
-        if: ${{ env.SKIP != 'yes' }} 
+        if: ${{ env.SKIP != 'yes' }}
         run: |
           ls -l build-kernel
           if [[ "$(cat build-kernel/skip 2> /dev/null || true)" == "no" ]]; then
@@ -418,7 +418,7 @@ jobs:
 
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -427,7 +427,7 @@ jobs:
           clean: false
 
       - name: Checkout support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -435,29 +435,29 @@ jobs:
           path: scripts
           clean: true
 
-      - name: Make board support packages        
+      - name: Make board support packages
         run: |
 
           if [[ "$(cat build-kernel/skip 2> /dev/null || true)" == "no" ]]; then
 
-            cd build              
+            cd build
             if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
                sudo mkdir -p cache/toolchain cache/rootfs || true
-               # umount 
+               # umount
                sudo umount cache/toolchain || true
                # erase below
                sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/*
                ! sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/* && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                ! sudo mountpoint -q cache/rootfs && sudo rm -rf cache/rootfs/* && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-            fi   
+            fi
 
             # use prepared configs
             sudo cp ../scripts/configs/* userpatches/
 
-            [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes          
-            ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" REPOSITORY_INSTALL="u-boot,kernel" 'prepare_host_basic'          
+            [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
+            ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" REPOSITORY_INSTALL="u-boot,kernel" 'prepare_host_basic'
             rm -rf output/debs*
-      
+
             ./compile.sh all-new-beta-bsp
             # wait until it finishes
             while :
@@ -468,7 +468,7 @@ jobs:
             done
           fi
 
-      - name: Deploy to server        
+      - name: Deploy to server
         run: |
 
           if [[ "$(cat build-kernel/skip 2> /dev/null || true)" == "no" ]]; then
@@ -487,7 +487,7 @@ jobs:
           git-user-signingkey: true
           git-commit-gpgsign: true
 
-      - name: Bump version        
+      - name: Bump version
         run: |
 
           if [[ "$(cat build-kernel/skip 2> /dev/null || true)" == "no" ]]; then

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   Cache:
-    
+
     name: Determine needed targets
     runs-on: [self-hosted, Linux, cache]
     if: ${{ github.repository_owner == 'armbian' }}
@@ -24,7 +24,7 @@ jobs:
                 sudo pkill aarch64-binfmt-P || true
                 sudo pkill pixz || true
                 sudo mountpoint -q build/output/images && sudo fusermount -u build/output/images || true
-                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break                
+                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break
                 echo "Mounted temp directories. Trying to unmount."
                 df | grep "/.tmp" | awk '{print $6}' | xargs sudo umount 2>/dev/null || true
                 sleep 10
@@ -32,7 +32,7 @@ jobs:
             sudo chown -R $USER:$USER build/.git
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -42,7 +42,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -75,7 +75,7 @@ jobs:
                 sudo mkdir -p cache/toolchain cache/rootfs || true
                 ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                 ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-            fi  
+            fi
             sudo rm -f userpatches/targets.conf
             cd ../scripts
             ./cacherebuild.sh  "" "../build-rootfs/filelist.txt"
@@ -97,11 +97,11 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Cache.outputs.matrix)}}
 
     steps:
- 
+
       - name: Cache Gradle packages
         uses: actions/cache@v2
         env:
@@ -129,10 +129,10 @@ jobs:
           [[ -d build/.git ]] && sudo chown -R $USER:$USER build/.git || true
           [[ -d build/output/images ]] && sudo rm -rf build/output/images/* || true
           [[ -d build/cache/sources ]] && sudo rm -rf build/cache/sources/* || true
-          
+
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -142,7 +142,7 @@ jobs:
 
       - name: Checkout Armbian support scripts
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -169,7 +169,7 @@ jobs:
               sudo mkdir -p build/cache/toolchain build/cache/rootfs || true
               ! sudo mountpoint -q build/cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com build/cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q build/cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs build/cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-          fi          
+          fi
           cd build
           # use prepared configs
           sudo mkdir -p userpatches
@@ -177,7 +177,7 @@ jobs:
           # prepare host
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes || true
           bash ../build-rootfs/split-${CHUNK}.conf
-          
+
   Finish:
     name: Finish
     needs: [Job]
@@ -194,7 +194,7 @@ jobs:
                 sudo pkill aarch64-binfmt-P || true
                 sudo pkill pixz || true
                 sudo mountpoint -q build/output/images && sudo fusermount -u build/output/images || true
-                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break                
+                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break
                 echo "Mounted temp directories. Trying to unmount."
                 df | grep ".tmp" | awk '{print $6}' | xargs sudo umount 2>/dev/null || true
                 sleep 10
@@ -202,7 +202,7 @@ jobs:
             sudo chown -R $USER:$USER build/.git
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -212,7 +212,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -245,6 +245,6 @@ jobs:
                 sudo mkdir -p cache/toolchain cache/rootfs || true
                 ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                 ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-            fi  
-            sudo rm -f userpatches/targets.conf            
+            fi
+            sudo rm -f userpatches/targets.conf
             ../scripts/cacherebuild.sh "yes"

--- a/.github/workflows/build-kernel-on-merge-request.yml
+++ b/.github/workflows/build-kernel-on-merge-request.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
        - name: Checkout repository
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
 
        - name: Environment variables
          run: sudo -E bash -c set
@@ -44,7 +44,7 @@ jobs:
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
       - name: Checkout Armbian build script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -61,8 +61,8 @@ jobs:
           sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf
 
   Prepare:
-    
-    name: "Finding changed kernels"    
+
+    name: "Finding changed kernels"
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Armbian' }}
     outputs:
@@ -85,7 +85,7 @@ jobs:
           echo "BETA=yes" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -94,7 +94,7 @@ jobs:
           clean: false
 
       - name: Checkout support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -113,9 +113,9 @@ jobs:
           mkdir -p cache/hash${FILE_EXT}
           sudo rsync -ar --delete ../scripts/hash${FILE_EXT}/. cache/hash${FILE_EXT}/ 2> /dev/null
           sudo cp ../scripts/configs/* userpatches/
-          sudo rm -f userpatches/targets.conf          
+          sudo rm -f userpatches/targets.conf
           if [[ "$(cat ../build-kernel/build_type 2> /dev/null || true)" =~ stable|edge ]]; then
-            cat config/targets.conf | grep edge | grep cli | grep hirsute | sudo tee userpatches/targets.conf 1>/dev/null 
+            cat config/targets.conf | grep edge | grep cli | grep hirsute | sudo tee userpatches/targets.conf 1>/dev/null
             echo "FILE_EXT=" >> $GITHUB_ENV
             echo "REPO_DEST=master" >> $GITHUB_ENV
             echo "BETA=no" >> $GITHUB_ENV
@@ -128,13 +128,13 @@ jobs:
           BETA="${{ env.BETA }}"
           MATRIX=$(cd build;./compile.sh all-new-beta-kernels BETA="$BETA" BUILD_ALL="demo" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | egrep "^[0-9]" | awk '{ print $2 ":" $4 }' | sort | uniq)
           mkdir -p build-kernel
-          echo "no" > build-kernel/skip          
+          echo "no" > build-kernel/skip
           if [[ -z "$MATRIX" ]]; then
               MATRIX="none:none"
               echo "yes" > build-kernel/skip
-          fi          
+          fi
           echo ::set-output name=matrix::$(for x in $(echo "${MATRIX}"); do echo $x; done|jq -cnR '[inputs | select(length>0)]' | jq)
-          
+
   Linux:
 
     name: "Build Linux"
@@ -144,13 +144,13 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Prepare.outputs.matrix)}}
 
     steps:
 
       - name: Checkout Armbian support scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -165,7 +165,7 @@ jobs:
           path: build-kernel
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux 
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}-linux
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Read value
@@ -182,7 +182,7 @@ jobs:
 
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -194,7 +194,7 @@ jobs:
         if: ${{ matrix.node != 'none:none' }}
         run: |
 
-              CHUNK="${{ matrix.node }}"              
+              CHUNK="${{ matrix.node }}"
               FILE_EXT="${{ env.FILE_EXT }}"
               BOARD=$(echo $CHUNK | cut -d":" -f1)
               BRANCH=$(echo $CHUNK | cut -d":" -f2)
@@ -202,8 +202,8 @@ jobs:
               cd build
               [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
               ./compile.sh ARMBIAN_MIRROR="https://github.com/armbian/mirror/releases/download/" BOARD="$BOARD" \
-              BETA="yes" KERNEL_ONLY="yes" BRANCH="$BRANCH" KERNEL_CONFIGURE="no" OFFLINE="no"              
-          
+              BETA="yes" KERNEL_ONLY="yes" BRANCH="$BRANCH" KERNEL_CONFIGURE="no" OFFLINE="no"
+
       - name: Upload build artifacts
         if: ${{ matrix.node != 'none:none' }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-single.yml
+++ b/.github/workflows/build-single.yml
@@ -43,7 +43,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -53,7 +53,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -82,7 +82,7 @@ jobs:
           run: |
 
             cd build
-           
+
             [[ "${REPOSITORY}" == "yes" ]] && REPOSITORY_INSTALL="u-boot,kernel,armbian-config,armbian-zsh,armbian-firmware"
             [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
             sudo apt -y -qq install git
@@ -92,13 +92,13 @@ jobs:
 
             if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
                 sudo mkdir -p cache/toolchain cache/rootfs || true
-                # umount 
+                # umount
                 sudo umount cache/toolchain || true
                 # erase below
                 sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/*
                 ! sudo mountpoint -q cache/toolchain && sudo rm -rf cache/toolchain/* && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                 ! sudo mountpoint -q cache/rootfs && sudo rm -rf cache/rootfs/* && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-            fi   
+            fi
 
             # sync rootfs
             mkdir -p cache/rootfs/

--- a/.github/workflows/build-stable-images.yml
+++ b/.github/workflows/build-stable-images.yml
@@ -45,7 +45,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -55,7 +55,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -155,7 +155,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -165,7 +165,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -265,7 +265,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -275,7 +275,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -375,7 +375,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -385,7 +385,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -485,7 +485,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -495,7 +495,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -595,7 +595,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -605,7 +605,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -705,7 +705,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -715,7 +715,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -815,7 +815,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -825,7 +825,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -925,7 +925,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -935,7 +935,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1035,7 +1035,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1045,7 +1045,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1145,7 +1145,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1155,7 +1155,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1255,7 +1255,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1265,7 +1265,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1365,7 +1365,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1375,7 +1375,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1475,7 +1475,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1485,7 +1485,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1585,7 +1585,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1595,7 +1595,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1695,7 +1695,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1705,7 +1705,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1805,7 +1805,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1815,7 +1815,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -1915,7 +1915,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -1925,7 +1925,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2025,7 +2025,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2035,7 +2035,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2135,7 +2135,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2145,7 +2145,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2245,7 +2245,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2255,7 +2255,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2355,7 +2355,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2365,7 +2365,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2465,7 +2465,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2475,7 +2475,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2575,7 +2575,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2585,7 +2585,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2685,7 +2685,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2695,7 +2695,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2795,7 +2795,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2805,7 +2805,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -2905,7 +2905,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -2915,7 +2915,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3015,7 +3015,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3025,7 +3025,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3125,7 +3125,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3135,7 +3135,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3235,7 +3235,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3245,7 +3245,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3345,7 +3345,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3355,7 +3355,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3455,7 +3455,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3465,7 +3465,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3565,7 +3565,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3575,7 +3575,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3675,7 +3675,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3685,7 +3685,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3785,7 +3785,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3795,7 +3795,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -3895,7 +3895,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -3905,7 +3905,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -4005,7 +4005,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -4015,7 +4015,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -4115,7 +4115,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -4125,7 +4125,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -4225,7 +4225,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -4235,7 +4235,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -4335,7 +4335,7 @@ jobs:
 
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -4345,7 +4345,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts

--- a/.github/workflows/build-u-boot.yml
+++ b/.github/workflows/build-u-boot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Prepare.outputs.matrix)}}
 
     steps:
@@ -72,8 +72,8 @@ jobs:
           done
           [[ -d build/.git ]] && sudo chown -R $USER:$USER build/.git || true
           [[ -d build/output/images ]] && sudo rm -rf build/output/images/* || true
- 
- 
+
+
       - name: Cache build configurations
         uses: actions/cache@v2
         env:
@@ -83,10 +83,10 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
- 
+
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -109,7 +109,7 @@ jobs:
               sudo mkdir -p cache/toolchain cache/rootfs || true
               ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-          fi  
+          fi
           ./compile.sh ARMBIAN_MIRROR="https://github.com/armbian/mirror/releases/download/" BOARD="$BOARD" PRIVATE_CCACHE="yes" BETA="yes" KERNEL_ONLY="yes" BRANCH="$BRANCH" KERNEL_CONFIGURE="no" OFFLINE="no" REPOSITORY_INSTALL="kernel,bsp,armbian-zsh,armbian-config,armbian-firmware"
           mkdir -p ../build-u-boot
           cp output/debs-beta/linux-u-boot-${BRANCH}-${BOARD}_$(cat VERSION)_* ../build-u-boot/

--- a/.github/workflows/docker-to-hub.yml
+++ b/.github/workflows/docker-to-hub.yml
@@ -14,10 +14,10 @@ jobs:
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
 
-     - uses: actions/checkout@v1
+     - uses: actions/checkout@v3
 
      - name: Login to DockerHub Registry
-       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin 
+       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
      - name: Build Docker image
        shell: bash {0}

--- a/.github/workflows/maintain.yml
+++ b/.github/workflows/maintain.yml
@@ -7,7 +7,7 @@ jobs:
 
   Prepare:
 
-    name: Prepare runners    
+    name: Prepare runners
     runs-on: [self-hosted, Linux, small]
     if: ${{ github.repository_owner == 'armbian' }}
     outputs:
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -29,18 +29,18 @@ jobs:
           echo ::set-output name=matrix::$(for x in $(seq -w 01 50); do echo $x; done|jq -cnR '[inputs | select(length>0)]' | jq)
 
   Maint:
-  
+
     needs: [ Prepare ]
     runs-on: [self-hosted, Linux, small]
     if: ${{ github.repository_owner == 'armbian' }}
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Prepare.outputs.matrix)}}
     steps:
       - name: Checkout Armbian build script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -67,14 +67,14 @@ jobs:
               df | grep ".tmp" | awk '{print $6}' | xargs sudo umount 2>/dev/null || true
               sleep 10
           done
-          sudo apt-get -y -qq update          
+          sudo apt-get -y -qq update
           sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y -qq upgrade
           [[ -d build/.git ]] && sudo chown -R $USER:$USER build/.git || true
           [[ -d build/output/images ]] && sudo rm -rf build/output/images/* || true
           cd build
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
           sudo rm -rf cache/sources
-          
+
           if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
               sudo rm -rf cache/toolchain
               sudo mkdir -p cache/toolchain cache/rootfs || true
@@ -83,10 +83,10 @@ jobs:
           fi
           ./compile.sh KERNEL_ONLY="yes" CLEAN_LEVEL="sources,alldebs" BOARD="bananapim64" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel,u-boot"
           sudo rm -rf output/debs
-          sudo rm -rf output/debs-beta          
+          sudo rm -rf output/debs-beta
 
   Cache:
-    
+
     name: Make cache
     needs: [ Maint ]
     runs-on: [self-hosted, Linux, cache]
@@ -105,7 +105,7 @@ jobs:
                 sudo pkill aarch64-binfmt-P || true
                 sudo pkill pixz || true
                 sudo mountpoint -q build/output/images && sudo fusermount -u build/output/images || true
-                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break                
+                [[ "$(df | grep "/.tmp" | wc -l)" -eq 0 ]] && sudo rm -rf build/.tmp && break
                 echo "Mounted temp directories. Trying to unmount."
                 df | grep ".tmp" | awk '{print $6}' | xargs sudo umount 2>/dev/null || true
                 sleep 10
@@ -113,7 +113,7 @@ jobs:
             sudo chown -R $USER:$USER build/.git
         - name: Checkout Armbian build script
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/build
@@ -123,7 +123,7 @@ jobs:
 
         - name: Checkout Armbian support scripts
 
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             repository: armbian/scripts
@@ -156,7 +156,7 @@ jobs:
                 sudo mkdir -p cache/toolchain cache/rootfs || true
                 ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
                 ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-            fi  
+            fi
             sudo rm -f userpatches/targets.conf
             cd ../scripts
             ./cacherebuild.sh
@@ -178,11 +178,11 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Cache.outputs.matrix)}}
 
     steps:
- 
+
       - name: Cache Gradle packages
         uses: actions/cache@v2
         env:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -223,7 +223,7 @@ jobs:
 
       - name: Checkout Armbian support scripts
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/scripts
@@ -250,7 +250,7 @@ jobs:
               sudo mkdir -p build/cache/toolchain build/cache/rootfs || true
               ! sudo mountpoint -q build/cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com build/cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q build/cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs build/cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-          fi          
+          fi
           cd build
           # use prepared configs
           sudo mkdir -p userpatches
@@ -281,7 +281,7 @@ jobs:
     timeout-minutes: 480
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         node: ${{fromJson(needs.Caches.outputs.matrix)}}
     steps:
       - run: echo Run ${{ matrix.run }}
@@ -294,7 +294,7 @@ jobs:
         run: |
 
           # make sure no temporally dirs are mounted from previous runs
-          
+
           while :
           do
               sudo pkill compile.sh || true
@@ -312,14 +312,14 @@ jobs:
 
       - name: Checkout Armbian build script
 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
           path: build
           ref: nightly
           clean: false
-          
+
       - name: Sync or mount rootfs
         run: |
 
@@ -345,7 +345,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER .
       - name: Checkout Armbian build script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: armbian/build
@@ -370,4 +370,4 @@ jobs:
     steps:
        - name: Run script
          run: |
-           echo "Finish"           
+           echo "Finish"

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
# Description

Node 12 version is deprecated since April 2022.

> Node.js 12 actions are deprecated. For more information see: [github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
